### PR TITLE
Add init command to available commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Un outil en ligne de commande conçu pour créer, gérer, superviser et supprime
 ## 🛠️ Commandes disponibles
 
 ```bash
+./core/supervisor.sh init            # Initialise l'environnement
 ./core/supervisor.sh create          # Crée une nouvelle instance
 ./core/supervisor.sh start <nom>     # Démarre une instance
 ./core/supervisor.sh stop <nom>      # Stoppe une instance


### PR DESCRIPTION
## Summary
- document `init` command in README under commands

## Testing
- `./core/supervisor.sh help`

------
https://chatgpt.com/codex/tasks/task_e_683f57659c748327be4e5b085d2da165